### PR TITLE
Fix Kisak i386 deps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,6 +39,7 @@ parts:
   debs:
     plugin: nil
     stage-packages:
+      - libgl1-mesa-glx:i386
       - libvkd3d1:i386
       - libvkd3d1:amd64
       - mesa-va-drivers:amd64
@@ -53,6 +54,9 @@ parts:
       - libvdpau-va-gl1:amd64
       - vulkan-tools # For testing/debugging
       - mesa-utils # For testing/debugging
+      # Only needed in the kisak branches, oibaf picks these up from the PPA
+      - libxml2:i386
+      - libstdc++6
     stage:
       - -usr/share/doc
       - -usr/share/man


### PR DESCRIPTION
This fixes issues with loading software and intel drivers in an i386 context by adding two missing dependencies from the `kisak` PPA dependency resolution. Should also be cherry-picked into kisak-turtle. The changes are unneeded (but probably non-destructive) in oibaf.