### PR TITLE
Fix oibaf meta version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -76,4 +76,4 @@ parts:
     override-prime: |
       craftctl default
       # Set the snap version from the mesa package version
-      craftctl set version=$(dpkg-parsechangelog -l $CRAFT_PART_INSTALL/usr/share/doc/mesa-va-drivers/changelog.gz -S Version | cut -c -32)
+      craftctl set version=$(dpkg-parsechangelog -l $CRAFT_PART_INSTALL/usr/share/doc/mesa-va-drivers/changelog.Debian.gz -S Version | cut -c -32)


### PR DESCRIPTION
All builds for Oibaf has been failing due to not being able to determine the version. All channels rely on getting the version information from `/root/parts/debs/install/usr/share/doc/mesa-va-drivers/changelog.gz`, but that file does not exist in the Oibaf channel. Instead, the `changelog.Debian.gz` file does exist, so this change uses that for version information instead.

This seemingly has the side effect of the version being something like `23.2.1-1ubuntu3.1~22.04.2` instead of the previous format which was something like `24.0~git2311260600.945288~oibaf~o`.
