### PR TITLE
ci: Add snap build action

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,21 @@
+name: snap
+on:
+  pull_request:
+  push:
+    branches:
+      - oibaf-latest-core22
+      - kisak-fresh-core22
+      - kisak-turtle-core22
+  workflow_dispatch:
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1
+      id: snapcraft
+    - uses: actions/upload-artifact@v4
+      with:
+        name: 'snap'
+        path: ${{ steps.snapcraft.outputs.snap}}


### PR DESCRIPTION
Added snap build action for easier testing.

This job will not succeed at the moment since Oibaf channel does not have working builds.