### PR TITLE
fix: Rename the gaming-mesa slot to gaming-graphics-core24 to fix upgrades

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,7 +11,7 @@ platforms:
 compression: lzo
 
 slots:
-  gaming-mesa:
+  gaming-graphics-core24:
     interface: content
     read:
       - /


### PR DESCRIPTION
Refreshing the steam snap while connected to gaming-graphics-core22:gaming-mesa didn't trigger installation of gaming-graphics-core24